### PR TITLE
Add support for comparison operators

### DIFF
--- a/lib/pgcrypto.rb
+++ b/lib/pgcrypto.rb
@@ -96,7 +96,7 @@ module PGCrypto
       pgcrypto_column_finder = pgcrypto_columns
       if key = PGCrypto.keys[:private]
         pgcrypto_column_finder = pgcrypto_column_finder.select([
-          %w(id owner_id owner_type owner_table).map {|column| %("#{PGCrypto::Column.table_name}"."#{column}")},
+          %w(id owner_id owner_type owner_table name).map {|column| %("#{PGCrypto::Column.table_name}"."#{column}")},
           %[pgp_pub_decrypt("#{PGCrypto::Column.table_name}"."value", pgcrypto_keys.#{key.name}#{key.password?}) AS "value"]
         ].flatten).joins(%[CROSS JOIN (SELECT #{key.dearmored} AS "#{key.name}") AS pgcrypto_keys])
       end

--- a/lib/pgcrypto.rb
+++ b/lib/pgcrypto.rb
@@ -24,7 +24,6 @@ module PGCrypto
 
       has_many :pgcrypto_columns, :as => :owner, :autosave => true, :class_name => 'PGCrypto::Column', :dependent => :delete_all
 
-
       pgcrypto_column_names.map(&:to_s).each do |column_name|
         # Stash the encryption type in our module so various monkeypatches can access it later!
         PGCrypto[table_name][column_name] = options.symbolize_keys

--- a/lib/pgcrypto.rb
+++ b/lib/pgcrypto.rb
@@ -1,4 +1,3 @@
-require 'big_spoon'
 require 'pgcrypto/active_record'
 require 'pgcrypto/arel'
 require 'pgcrypto/column'
@@ -25,14 +24,6 @@ module PGCrypto
 
       has_many :pgcrypto_columns, :as => :owner, :autosave => true, :class_name => 'PGCrypto::Column', :dependent => :delete_all
 
-      hooks do
-        before(:reload) do
-          self.class.pgcrpyto_columns.each do |column_name, options|
-            reset_attribute! column_name
-            changed_attributes.delete(column_name)
-          end
-        end
-      end
 
       pgcrypto_column_names.map(&:to_s).each do |column_name|
         # Stash the encryption type in our module so various monkeypatches can access it later!
@@ -83,6 +74,20 @@ module PGCrypto
   end
 
   module InstanceMethods
+    def self.included(base)
+      base.class_eval do
+        alias original_reload reload
+
+        def reload
+          self.class.pgcrpyto_columns.each do |column_name, options|
+            reset_attribute! column_name
+            changed_attributes.delete(column_name)
+          end
+          original_reload
+        end
+      end
+    end
+
     def select_pgcrypto_column(column_name)
       return nil if new_record?
       # Now here's the fun part. We want the selector on PGCrypto columns to do the decryption

--- a/lib/pgcrypto.rb
+++ b/lib/pgcrypto.rb
@@ -45,7 +45,7 @@ module PGCrypto
           attribute_will_change!(:#{column_name}) if value != @_pgcrypto_#{column_name}.try(:value)
           if value.nil?
             pgcrypto_columns.select{|column| column.name == "#{column_name}"}.each(&:mark_for_destruction)
-            remove_instance_variable("@_pgcrypto_#{column_name}") if defined?(@_pgcrypto_#{column_name})
+            @_pgcrypto_#{column_name} = nil
           else
             @_pgcrypto_#{column_name} ||= pgcrypto_columns.select{|column| column.name == "#{column_name}"}.first || pgcrypto_columns.new(:name => "#{column_name}")
             pgcrypto_columns.push(@_pgcrypto_#{column_name})

--- a/lib/pgcrypto.rb
+++ b/lib/pgcrypto.rb
@@ -78,12 +78,12 @@ module PGCrypto
       base.class_eval do
         alias original_reload reload
 
-        def reload
+        def reload(*args)
           self.class.pgcrpyto_columns.each do |column_name, options|
             reset_attribute! column_name
             changed_attributes.delete(column_name)
           end
-          original_reload
+          original_reload(*args)
         end
       end
     end

--- a/lib/pgcrypto/active_record.rb
+++ b/lib/pgcrypto/active_record.rb
@@ -58,6 +58,7 @@ ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.class_eval do
         end
         # Now loop through the children to encrypt them for the SELECT
         children.each do |child|
+          next unless child.respond_to?(:left) and child.left.respond_to?(:name)
           column_options = encrypted_columns[child.left.name.to_s]
           next unless column_options
           joins.push(child.left.name.to_s) unless joins.include?(child.left.name.to_s)

--- a/lib/pgcrypto/active_record.rb
+++ b/lib/pgcrypto/active_record.rb
@@ -49,14 +49,21 @@ ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.class_eval do
       # We loop through each WHERE specification to determine whether or not the
       # PGCrypto column should be JOIN'd upon; in which case, we, like, do it.
       core.wheres.each do |where|
+        if where.respond_to?(:children)
+          children = where.children
+        elsif where.respond_to?(:expr)
+          children = [where.expr]
+        else
+          children = []
+        end
         # Now loop through the children to encrypt them for the SELECT
-        where.children.each do |child|
+        children.each do |child|
           next unless encrypted_columns[child.left.name.to_s]
           joins.push(child.left.name.to_s) unless joins.include?(child.left.name.to_s)
           child.left = Arel::Nodes::SqlLiteral.new(%[
             pgp_pub_decrypt("#{PGCrypto::Column.table_name}_#{child.left.name}"."value", pgcrypto_keys.#{key.name}#{key.password?})
           ])
-        end if where.respond_to?(:children)
+        end
       end
     end
     if joins.any?

--- a/lib/pgcrypto/active_record.rb
+++ b/lib/pgcrypto/active_record.rb
@@ -6,7 +6,7 @@ ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.class_eval do
   end
 
   def to_sql(arel, *args)
-    arel = Marshal.load(Marshal.dump(arel)) # TODO: Need a better way to avoid mutation
+    arel = Marshal.load(Marshal.dump(arel)) rescue arel = arel.dup # TODO: Need a better way to avoid mutation
     case arel
     when Arel::InsertManager
       pgcrypto_tweak_insert(arel)

--- a/lib/pgcrypto/active_record.rb
+++ b/lib/pgcrypto/active_record.rb
@@ -6,6 +6,7 @@ ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.class_eval do
   end
 
   def to_sql(arel, *args)
+    arel = Marshal.load(Marshal.dump(arel)) # TODO: Need a better way to avoid mutation
     case arel
     when Arel::InsertManager
       pgcrypto_tweak_insert(arel)

--- a/lib/pgcrypto/column.rb
+++ b/lib/pgcrypto/column.rb
@@ -5,7 +5,7 @@ module PGCrypto
     before_save :set_owner_table
     belongs_to :owner, :autosave => false, :inverse_of => :pgcrypto_columns, :polymorphic => true
 
-    default_scope select(%w(id owner_id owner_type owner_table))
+    default_scope select(%w(id owner_id owner_type owner_table name))
 
     protected
     def set_owner_table

--- a/pgcrypto.gemspec
+++ b/pgcrypto.gemspec
@@ -54,16 +54,13 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<activerecord>, [">= 3.2"])
-      s.add_runtime_dependency(%q<big_spoon>, [">= 0.2.1"])
       s.add_development_dependency(%q<jeweler>, [">= 0"])
     else
       s.add_dependency(%q<activerecord>, [">= 3.2"])
-      s.add_dependency(%q<big_spoon>, [">= 0.2.1"])
       s.add_dependency(%q<jeweler>, [">= 0"])
     end
   else
     s.add_dependency(%q<activerecord>, [">= 3.2"])
-    s.add_dependency(%q<big_spoon>, [">= 0.2.1"])
     s.add_dependency(%q<jeweler>, [">= 0"])
   end
 end

--- a/spec/lib/joined_associations_spec.rb
+++ b/spec/lib/joined_associations_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe 'Joined assocations' do
+  before do
+    keypath = File.expand_path(File.join(File.dirname(__FILE__), '..', 'support'))
+    PGCrypto.keys[:private] = {:path => File.join(keypath, 'private.key')}
+    PGCrypto.keys[:public] = {:path => File.join(keypath, 'public.key')}
+  end
+
+  it 'should not typecast to integer' do
+    foo = Foo.create!(address: 'asdf')
+    bar = foo.bars.create!
+    Bar.joins(:foo).where(foos: { address: 'asdf' }).should include(bar)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,6 +44,15 @@ RSpec.configure do |config|
         create_table :pgcrypto_test_models, :force => true do |t|
           t.string :name, :limit => 32
         end
+
+        create_table :foos, force: true do |t|
+          t.timestamps
+        end
+
+        create_table :bars, force: true do |t|
+          t.integer :foo_id
+          t.timestamps
+        end
       end
     end
   end
@@ -58,6 +67,16 @@ RSpec.configure do |config|
     class PGCryptoTestModel < ActiveRecord::Base
       self.table_name = :pgcrypto_test_models
       pgcrypto :test_column
+    end
+
+    class Foo < ActiveRecord::Base
+      pgcrypto :address
+      has_many :bars
+    end
+
+    class Bar < ActiveRecord::Base
+      pgcrypto :something
+      belongs_to :foo
     end
   end
 


### PR DESCRIPTION
This includes a few simple changes required to support comparison operators such as < and >. A minor tweak was made to the select statement tweaker since the node created by a statement such as the following does not respond to :children.

```
t = arel_table
where(t[:numeric].gt(1))
```

In addition, since postgres does not perform implicit typecasting from string to integer when < is used, an optional column_type parameter is used on the pgcrypto class method. The value given to it is directly appended to the select statement to perform typecasting.
